### PR TITLE
Security hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.claude/settings.local.json
 
 # rspec failure tracking
 .rspec_status

--- a/lib/mini_tarball/header_parser.rb
+++ b/lib/mini_tarball/header_parser.rb
@@ -62,7 +62,14 @@ module MiniTarball
           parse_base256(raw)
         else
           stripped = raw.strip
-          stripped.empty? ? nil : stripped.to_i(8)
+          return nil if stripped.empty?
+
+          # Reject negative octal values
+          if stripped.start_with?("-")
+            raise InvalidHeaderError, "Negative octal values not supported"
+          end
+
+          stripped.to_i(8)
         end
       end
 

--- a/lib/mini_tarball/header_parser.rb
+++ b/lib/mini_tarball/header_parser.rb
@@ -55,17 +55,23 @@ module MiniTarball
       end
 
       def parse_number(raw)
-        return nil if raw.nil? || raw.strip.empty?
+        return nil if raw.nil?
 
         # Check for base-256 encoding (high bit set)
         if raw.getbyte(0) & 0x80 != 0
           parse_base256(raw)
         else
-          raw.strip.to_i(8)
+          stripped = raw.strip
+          stripped.empty? ? nil : stripped.to_i(8)
         end
       end
 
       def parse_base256(raw)
+        # Check sign bit (bit 6 of first byte after marker)
+        if raw.getbyte(0) & 0x40 != 0
+          raise InvalidHeaderError, "Negative base-256 values not supported"
+        end
+
         bytes = raw.bytes
         bytes[0] &= 0x7F # Clear the marker bit
         bytes.inject(0) { |acc, byte| (acc << 8) | byte }

--- a/lib/mini_tarball/header_parser.rb
+++ b/lib/mini_tarball/header_parser.rb
@@ -15,7 +15,8 @@ module MiniTarball
 
   class HeaderParser
     def self.parse(binary_data)
-      return nil if binary_data.nil? || binary_data.bytesize < Header::BLOCK_SIZE
+      return nil if binary_data.nil?
+      raise InvalidHeaderError, "Truncated header" if binary_data.bytesize < Header::BLOCK_SIZE
       return nil if end_of_archive?(binary_data)
 
       values = unpack_fields(binary_data)

--- a/lib/mini_tarball/reader.rb
+++ b/lib/mini_tarball/reader.rb
@@ -15,9 +15,18 @@ module MiniTarball
     end
   end
 
+  class TruncatedArchiveError < StandardError
+    def initialize(msg = "Archive is truncated")
+      super
+    end
+  end
+
   class Reader
     # Maximum size for long name/linkname entries (64KB)
     MAX_LONG_NAME_SIZE = 65_535
+
+    # Maximum number of internal headers (long name/linkname) to prevent DoS
+    MAX_INTERNAL_HEADERS = 200_000
 
     # Chunk size for skipping content (64KB)
     SKIP_CHUNK_SIZE = 65_536
@@ -32,6 +41,7 @@ module MiniTarball
     DEFAULT_MAX_ENTRY_COUNT = 100_000
 
     private_constant :MAX_LONG_NAME_SIZE,
+                     :MAX_INTERNAL_HEADERS,
                      :SKIP_CHUNK_SIZE,
                      :DEFAULT_MAX_FILE_SIZE,
                      :DEFAULT_MAX_TOTAL_SIZE,
@@ -71,6 +81,7 @@ module MiniTarball
       long_name = nil
       total_size = 0
       entry_count = 0
+      internal_header_count = 0
 
       loop do
         header_data = @io.read(Header::BLOCK_SIZE)
@@ -82,6 +93,14 @@ module MiniTarball
         # Handle GNU long linkname (typeflag K) for long symlink/hardlink targets
         if values[:typeflag] == "K"
           raise InvalidHeaderError, "Long linkname too large" if values[:size] > MAX_LONG_NAME_SIZE
+          internal_header_count += 1
+          if internal_header_count > MAX_INTERNAL_HEADERS
+            raise ArchiveLimitError, "Too many internal headers"
+          end
+          total_size += values[:size]
+          if total_size > @max_total_size
+            raise ArchiveLimitError, "Total size exceeds maximum (#{@max_total_size} bytes)"
+          end
           long_linkname = read_content(values[:size]).delete("\0")
           skip_padding(values[:size])
           next
@@ -90,6 +109,14 @@ module MiniTarball
         # Handle GNU long link (typeflag L) for long filenames
         if values[:typeflag] == "L"
           raise InvalidHeaderError, "Long name too large" if values[:size] > MAX_LONG_NAME_SIZE
+          internal_header_count += 1
+          if internal_header_count > MAX_INTERNAL_HEADERS
+            raise ArchiveLimitError, "Too many internal headers"
+          end
+          total_size += values[:size]
+          if total_size > @max_total_size
+            raise ArchiveLimitError, "Total size exceeds maximum (#{@max_total_size} bytes)"
+          end
           long_name = read_content(values[:size]).delete("\0")
           skip_padding(values[:size])
           next
@@ -173,26 +200,33 @@ module MiniTarball
     end
 
     def read_content(size)
-      @io.read(size)
+      data = @io.read(size)
+      raise TruncatedArchiveError, "Unexpected end of archive" if data.nil? || data.bytesize < size
+      data
     end
 
     def skip_remaining(bytes)
       while bytes > 0
         chunk = [bytes, SKIP_CHUNK_SIZE].min
-        @io.read(chunk)
-        bytes -= chunk
+        data = @io.read(chunk)
+        raise TruncatedArchiveError, "Unexpected end of archive" if data.nil?
+        bytes -= data.bytesize
       end
     end
 
     def skip_padding(content_size)
       padding = (Header::BLOCK_SIZE - (content_size % Header::BLOCK_SIZE)) % Header::BLOCK_SIZE
-      @io.read(padding) if padding > 0
+      return if padding == 0
+
+      data = @io.read(padding)
+      raise TruncatedArchiveError, "Unexpected end of archive" if data.nil? || data.bytesize < padding
     end
 
     def extract_entry(entry, stream, destination)
       target_path = safe_path(entry.name, destination)
 
       if entry.directory?
+        ensure_not_symlink_target(target_path)
         FileUtils.mkdir_p(target_path)
       elsif entry.symlink?
         validate_symlink_target(entry.linkname, destination, target_path)
@@ -200,9 +234,12 @@ module MiniTarball
         File.symlink(entry.linkname, target_path)
       elsif entry.hardlink?
         link_target = safe_path(entry.linkname, destination)
+        ensure_not_symlink_target(target_path)
+        ensure_not_symlink_target(link_target)
         FileUtils.mkdir_p(File.dirname(target_path))
         File.link(link_target, target_path)
       elsif entry.file?
+        ensure_not_symlink_target(target_path)
         FileUtils.mkdir_p(File.dirname(target_path))
         File.open(target_path, "wb") { |f| IO.copy_stream(stream, f) }
         File.chmod(entry.mode, target_path) if entry.mode
@@ -212,15 +249,14 @@ module MiniTarball
     def safe_path(name, destination)
       # Remove leading slashes and resolve the path
       clean_name = name.sub(%r{^/+}, "")
-      full_path = File.expand_path(File.join(destination, clean_name))
+      full_path = normalize_path(File.expand_path(File.join(destination, clean_name)))
+      normalized_dest = normalize_path(destination)
 
       # Ensure the resolved path is within destination
-      unless full_path.start_with?(destination + "/") || full_path == destination
-        raise PathTraversalError
-      end
+      raise PathTraversalError unless path_within?(full_path, normalized_dest)
 
       # Verify no symlinks in existing path components could escape
-      validate_path_components(full_path, destination)
+      validate_path_components(full_path, normalized_dest)
 
       full_path
     end
@@ -236,8 +272,8 @@ module MiniTarball
         next unless File.symlink?(path)
 
         # Resolve symlink and verify it stays within destination
-        resolved = File.realpath(path)
-        unless resolved.start_with?(destination + "/") || resolved == destination
+        resolved = normalize_path(File.realpath(path))
+        unless path_within?(resolved, destination)
           raise PathTraversalError, "Symlink in path escapes destination"
         end
       end
@@ -252,11 +288,25 @@ module MiniTarball
         raise PathTraversalError
       else
         # Relative symlink - check where it resolves
-        resolved = File.expand_path(target, File.dirname(link_path))
-        unless resolved.start_with?(destination + "/") || resolved == destination
-          raise PathTraversalError
-        end
+        resolved = normalize_path(File.expand_path(target, File.dirname(link_path)))
+        raise PathTraversalError unless path_within?(resolved, destination)
       end
+    end
+
+    def ensure_not_symlink_target(path)
+      return unless File.symlink?(path)
+
+      raise PathTraversalError, "Symlink at destination path"
+    end
+
+    # Normalize path separators to forward slashes for consistent comparison
+    def normalize_path(path)
+      path.tr("\\", "/")
+    end
+
+    # Check if path is within or equal to destination
+    def path_within?(path, destination)
+      path == destination || path.start_with?(destination + "/")
     end
   end
 end

--- a/lib/mini_tarball/reader.rb
+++ b/lib/mini_tarball/reader.rb
@@ -9,6 +9,12 @@ module MiniTarball
     end
   end
 
+  class ArchiveLimitError < StandardError
+    def initialize(msg = "Archive limit exceeded")
+      super
+    end
+  end
+
   class Reader
     # Maximum size for long name/linkname entries (64KB)
     MAX_LONG_NAME_SIZE = 65_535
@@ -19,18 +25,40 @@ module MiniTarball
     # Default maximum file size (8GB)
     DEFAULT_MAX_FILE_SIZE = 8_589_934_592
 
-    private_constant :MAX_LONG_NAME_SIZE, :SKIP_CHUNK_SIZE, :DEFAULT_MAX_FILE_SIZE
+    # Default maximum total size (50GB)
+    DEFAULT_MAX_TOTAL_SIZE = 53_687_091_200
 
-    def self.use(io, max_file_size: DEFAULT_MAX_FILE_SIZE)
-      reader = new(io, max_file_size:)
+    # Default maximum entry count (100,000)
+    DEFAULT_MAX_ENTRY_COUNT = 100_000
+
+    private_constant :MAX_LONG_NAME_SIZE,
+                     :SKIP_CHUNK_SIZE,
+                     :DEFAULT_MAX_FILE_SIZE,
+                     :DEFAULT_MAX_TOTAL_SIZE,
+                     :DEFAULT_MAX_ENTRY_COUNT
+
+    def self.use(
+      io,
+      max_file_size: DEFAULT_MAX_FILE_SIZE,
+      max_total_size: DEFAULT_MAX_TOTAL_SIZE,
+      max_entry_count: DEFAULT_MAX_ENTRY_COUNT
+    )
+      reader = new(io, max_file_size:, max_total_size:, max_entry_count:)
       yield reader
     ensure
       reader&.close
     end
 
-    def initialize(io, max_file_size: DEFAULT_MAX_FILE_SIZE)
+    def initialize(
+      io,
+      max_file_size: DEFAULT_MAX_FILE_SIZE,
+      max_total_size: DEFAULT_MAX_TOTAL_SIZE,
+      max_entry_count: DEFAULT_MAX_ENTRY_COUNT
+    )
       @io = io
       @max_file_size = max_file_size
+      @max_total_size = max_total_size
+      @max_entry_count = max_entry_count
       @closed = false
     end
 
@@ -41,6 +69,8 @@ module MiniTarball
 
       long_linkname = nil
       long_name = nil
+      total_size = 0
+      entry_count = 0
 
       loop do
         header_data = @io.read(Header::BLOCK_SIZE)
@@ -74,6 +104,18 @@ module MiniTarball
         # Validate file size
         if values[:size] && values[:size] > @max_file_size
           raise InvalidHeaderError, "File size exceeds maximum (#{@max_file_size} bytes)"
+        end
+
+        # Validate entry count
+        entry_count += 1
+        if entry_count > @max_entry_count
+          raise ArchiveLimitError, "Entry count exceeds maximum (#{@max_entry_count})"
+        end
+
+        # Validate total size
+        total_size += values[:size] || 0
+        if total_size > @max_total_size
+          raise ArchiveLimitError, "Total size exceeds maximum (#{@max_total_size} bytes)"
         end
 
         entry = Entry.new(values)

--- a/lib/mini_tarball/reader.rb
+++ b/lib/mini_tarball/reader.rb
@@ -146,7 +146,28 @@ module MiniTarball
         raise PathTraversalError
       end
 
+      # Verify no symlinks in existing path components could escape
+      validate_path_components(full_path, destination)
+
       full_path
+    end
+
+    def validate_path_components(full_path, destination)
+      # Check each existing directory component for symlinks escaping destination
+      path = destination
+      relative = full_path.delete_prefix(destination + "/")
+
+      # Check all components except the last (which is the file/dir being created)
+      relative.split("/")[0..-2].each do |component|
+        path = File.join(path, component)
+        next unless File.symlink?(path)
+
+        # Resolve symlink and verify it stays within destination
+        resolved = File.realpath(path)
+        unless resolved.start_with?(destination + "/") || resolved == destination
+          raise PathTraversalError, "Symlink in path escapes destination"
+        end
+      end
     end
 
     def validate_symlink_target(target, destination, link_path)

--- a/lib/mini_tarball/reader.rb
+++ b/lib/mini_tarball/reader.rb
@@ -10,6 +10,10 @@ module MiniTarball
   end
 
   class Reader
+    # Maximum size for long name/linkname entries (64KB)
+    MAX_LONG_NAME_SIZE = 65_535
+    private_constant :MAX_LONG_NAME_SIZE
+
     def self.use(io)
       reader = new(io)
       yield reader
@@ -39,6 +43,7 @@ module MiniTarball
 
         # Handle GNU long linkname (typeflag K) for long symlink/hardlink targets
         if values[:typeflag] == "K"
+          raise InvalidHeaderError, "Long linkname too large" if values[:size] > MAX_LONG_NAME_SIZE
           long_linkname = read_content(values[:size]).delete("\0")
           skip_padding(values[:size])
           next
@@ -46,6 +51,7 @@ module MiniTarball
 
         # Handle GNU long link (typeflag L) for long filenames
         if values[:typeflag] == "L"
+          raise InvalidHeaderError, "Long name too large" if values[:size] > MAX_LONG_NAME_SIZE
           long_name = read_content(values[:size]).delete("\0")
           skip_padding(values[:size])
           next

--- a/lib/mini_tarball/reader.rb
+++ b/lib/mini_tarball/reader.rb
@@ -16,17 +16,21 @@ module MiniTarball
     # Chunk size for skipping content (64KB)
     SKIP_CHUNK_SIZE = 65_536
 
-    private_constant :MAX_LONG_NAME_SIZE, :SKIP_CHUNK_SIZE
+    # Default maximum file size (8GB)
+    DEFAULT_MAX_FILE_SIZE = 8_589_934_592
 
-    def self.use(io)
-      reader = new(io)
+    private_constant :MAX_LONG_NAME_SIZE, :SKIP_CHUNK_SIZE, :DEFAULT_MAX_FILE_SIZE
+
+    def self.use(io, max_file_size: DEFAULT_MAX_FILE_SIZE)
+      reader = new(io, max_file_size:)
       yield reader
     ensure
       reader&.close
     end
 
-    def initialize(io)
+    def initialize(io, max_file_size: DEFAULT_MAX_FILE_SIZE)
       @io = io
+      @max_file_size = max_file_size
       @closed = false
     end
 
@@ -66,6 +70,11 @@ module MiniTarball
         values[:linkname] = long_linkname if long_linkname
         long_name = nil
         long_linkname = nil
+
+        # Validate file size
+        if values[:size] && values[:size] > @max_file_size
+          raise InvalidHeaderError, "File size exceeds maximum (#{@max_file_size} bytes)"
+        end
 
         entry = Entry.new(values)
         content_stream = BoundedReadStream.new(@io, size: entry.size)

--- a/lib/mini_tarball/reader.rb
+++ b/lib/mini_tarball/reader.rb
@@ -12,7 +12,11 @@ module MiniTarball
   class Reader
     # Maximum size for long name/linkname entries (64KB)
     MAX_LONG_NAME_SIZE = 65_535
-    private_constant :MAX_LONG_NAME_SIZE
+
+    # Chunk size for skipping content (64KB)
+    SKIP_CHUNK_SIZE = 65_536
+
+    private_constant :MAX_LONG_NAME_SIZE, :SKIP_CHUNK_SIZE
 
     def self.use(io)
       reader = new(io)
@@ -100,7 +104,11 @@ module MiniTarball
     end
 
     def skip_remaining(bytes)
-      @io.read(bytes) if bytes > 0
+      while bytes > 0
+        chunk = [bytes, SKIP_CHUNK_SIZE].min
+        @io.read(chunk)
+        bytes -= chunk
+      end
     end
 
     def skip_padding(content_size)

--- a/lib/mini_tarball/reader.rb
+++ b/lib/mini_tarball/reader.rb
@@ -130,6 +130,28 @@ module MiniTarball
       self
     end
 
+    # Iterates over regular file entries only, skipping directories and links.
+    # Convenient for streaming file contents without filesystem extraction.
+    #
+    # @example Streaming files to S3
+    #   Reader.use(tar_io) do |reader|
+    #     reader.each_file do |entry, stream|
+    #       s3.put_object(bucket: "bucket", key: entry.name, body: stream)
+    #     end
+    #   end
+    #
+    # @yield [entry, stream] Yields each file entry and its content stream
+    # @yieldparam entry [Entry] The file entry metadata
+    # @yieldparam stream [BoundedReadStream] The file content stream
+    # @return [Enumerator, self] Returns Enumerator if no block given, self otherwise
+    def each_file
+      return enum_for(:each_file) unless block_given?
+
+      each_entry { |entry, stream| yield entry, stream if entry.file? }
+
+      self
+    end
+
     def extract_all(destination)
       destination = File.expand_path(destination)
       FileUtils.mkdir_p(destination)

--- a/lib/mini_tarball/streams/bounded_read_stream.rb
+++ b/lib/mini_tarball/streams/bounded_read_stream.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 module MiniTarball
+  # A read-only stream that limits reads to a specified size.
+  # Compatible with IO.copy_stream and most upload SDKs (AWS S3, GCS, etc.)
+  #
+  # @example Streaming to S3
+  #   Reader.use(tar_io) do |reader|
+  #     reader.each_entry do |entry, stream|
+  #       next unless entry.file?
+  #       s3.put_object(bucket: "bucket", key: entry.name, body: stream)
+  #     end
+  #   end
   class BoundedReadStream
+    attr_reader :size, :remaining
+
     def initialize(io, size:)
       @io = io
+      @size = size
       @remaining = size
     end
 
@@ -20,6 +33,11 @@ module MiniTarball
       @remaining == 0
     end
 
-    attr_reader :remaining
+    # Bytes read so far
+    def pos
+      @size - @remaining
+    end
+
+    alias_method :tell, :pos
   end
 end

--- a/lib/mini_tarball/writer.rb
+++ b/lib/mini_tarball/writer.rb
@@ -139,6 +139,7 @@ module MiniTarball
     )
       ensure_not_closed
       ensure_safe_name(name)
+      ensure_safe_target(target)
 
       @header_writer.write(
         Header.new(
@@ -171,6 +172,7 @@ module MiniTarball
     )
       ensure_not_closed
       ensure_safe_name(name)
+      ensure_safe_target(target)
 
       @header_writer.write(
         Header.new(
@@ -346,11 +348,28 @@ module MiniTarball
     end
 
     private def ensure_safe_name(name)
-      raise UnsafeNameError, "Absolute paths are not allowed: #{name}" if name.start_with?("/")
+      raise UnsafeNameError, "Empty name not allowed" if name.nil? || name.empty?
+      raise UnsafeNameError, "Absolute paths are not allowed: #{name}" if absolute_path?(name)
+      raise UnsafeNameError, "Path traversal is not allowed: #{name}" if path_traversal?(name)
+    end
 
-      if name.start_with?("../") || name.end_with?("/..") || name.include?("/../")
-        raise UnsafeNameError, "Path traversal is not allowed: #{name}"
+    private def ensure_safe_target(target)
+      # Targets can be relative to the entry, so we're more lenient
+      # But reject absolute paths
+      if absolute_path?(target)
+        raise UnsafeNameError, "Absolute target paths are not allowed: #{target}"
       end
+    end
+
+    private def absolute_path?(path)
+      path.start_with?("/") || path.match?(%r{\A[A-Za-z]:[\\/]}) || path.start_with?("\\") # Unix absolute # Windows drive letter # Windows UNC
+    end
+
+    private def path_traversal?(name)
+      # Normalize backslashes for checking
+      normalized = name.tr("\\", "/")
+      normalized == ".." || normalized.start_with?("../") || normalized.end_with?("/..") ||
+        normalized.include?("/../")
     end
 
     private def lookup_username(uid)

--- a/lib/mini_tarball/writer.rb
+++ b/lib/mini_tarball/writer.rb
@@ -192,6 +192,27 @@ module MiniTarball
       self
     end
 
+    # Adds a file by streaming content from a block.
+    #
+    # @param name [String] The filename in the archive
+    # @param size [Integer, nil] Expected content size. Required for non-seekable IO (e.g., gzip).
+    #   If omitted, the IO must be seekable so the size can be determined after writing.
+    #
+    # @note When +size+ is provided, it MUST match the actual bytes written. If fewer bytes
+    #   are written, the remainder is filled with NUL bytes. When the archive is later read
+    #   or extracted, the declared size is used - there is no way to distinguish padding from
+    #   intentional content. This affects both streaming (e.g., S3 uploads include the padding)
+    #   and disk extraction (extracted files will have the declared size, not actual content size).
+    #
+    # @example With seekable IO (size determined automatically)
+    #   writer.add_file_from_stream(name: "test.txt") { |s| s.write("hello") }
+    #
+    # @example With non-seekable IO (gzip) - size must be exact
+    #   content = "hello"
+    #   writer.add_file_from_stream(name: "test.txt", size: content.bytesize) do |s|
+    #     s.write(content)
+    #   end
+    #
     # :reek:ControlParameter
     # :reek:DuplicateMethodCall { allow_calls: ['@io.pos'] }
     # :reek:LongParameterList
@@ -230,6 +251,16 @@ module MiniTarball
       self
     end
 
+    # Reserves space for a file to be filled later via Placeholder#fill.
+    # Useful when file content isn't available yet but position in archive matters.
+    #
+    # @param name [String] The filename in the archive
+    # @param size [Integer] Reserved size in bytes
+    # @return [Placeholder] A placeholder that can be filled later
+    #
+    # @note The +size+ declares the maximum content. If less is written when filling,
+    #   the remainder stays as NUL bytes. See {#add_file_from_stream} for implications.
+    #
     # :reek:DuplicateMethodCall { allow_calls: ['@io.pos'] }
     def add_file_placeholder(name:, size:)
       ensure_not_closed
@@ -354,6 +385,7 @@ module MiniTarball
     end
 
     private def ensure_safe_target(target)
+      raise UnsafeNameError, "Empty target not allowed" if target.nil? || target.empty?
       # Targets can be relative to the entry, so we're more lenient
       # But reject absolute paths
       if absolute_path?(target)

--- a/spec/header_parser_spec.rb
+++ b/spec/header_parser_spec.rb
@@ -117,6 +117,19 @@ RSpec.describe MiniTarball::HeaderParser do
       )
     end
 
+    it "raises InvalidHeaderError for negative octal size" do
+      tar_data = create_tar_with_file("hello")
+      header_data = tar_data[0, 512].dup.force_encoding(Encoding::BINARY)
+      # Size field at offset 124, write "-1" in octal format
+      header_data[SIZE_FIELD_OFFSET, 12] = "-1".ljust(12, "\0")
+      header_data = recalculate_checksum(header_data)
+
+      expect { described_class.parse(header_data) }.to raise_error(
+        MiniTarball::InvalidHeaderError,
+        "Negative octal values not supported",
+      )
+    end
+
     it "parses positive base-256 values with high values correctly" do
       # Positive base-256: bit 7 set, bit 6 clear = 0x80
       # This encodes the value 1000 (0x3E8) in base-256

--- a/spec/header_parser_spec.rb
+++ b/spec/header_parser_spec.rb
@@ -73,12 +73,27 @@ RSpec.describe MiniTarball::HeaderParser do
   end
 
   context "with base-256 encoded size" do
+    # Size field is at offset 124 (100+8+8+8) and is 12 bytes long
+    SIZE_FIELD_OFFSET = 124
+
+    def create_header_with_base256_size(size_bytes)
+      tar_data = create_tar_with_file("hello")
+      header_data = tar_data[0, 512].dup.force_encoding(Encoding::BINARY)
+      header_data[SIZE_FIELD_OFFSET, 12] = size_bytes
+      recalculate_checksum(header_data)
+    end
+
+    def recalculate_checksum(header_data)
+      checksum_offset = 148
+      header_data[checksum_offset, 8] = " " * 8
+      checksum = header_data.bytes.sum
+      header_data[checksum_offset, 8] = format("%06o\0 ", checksum)
+      header_data
+    end
+
     it "parses large file sizes correctly" do
-      # Create a header with base-256 encoded size
-      # This is tested indirectly through the Writer which uses base-256 for large files
       io = StringIO.new.binmode
       MiniTarball::Writer.use(io) do |writer|
-        # Use add_file_from_stream with a large declared size
         writer.add_file_from_stream(name: "big.txt", size: 8_589_934_592) do |s|
           # Don't actually write 8GB, just test the header
         end
@@ -88,6 +103,28 @@ RSpec.describe MiniTarball::HeaderParser do
       values = described_class.parse(header_data)
 
       expect(values[:size]).to eq(8_589_934_592)
+    end
+
+    it "raises InvalidHeaderError for negative base-256 size" do
+      # Negative base-256: bit 7 (marker) and bit 6 (sign) both set = 0xC0+
+      # This represents -1 in base-256 (all 0xFF after the marker)
+      negative_size = (+"\xFF" * 12).force_encoding(Encoding::BINARY)
+      header_data = create_header_with_base256_size(negative_size)
+
+      expect { described_class.parse(header_data) }.to raise_error(
+        MiniTarball::InvalidHeaderError,
+        "Negative base-256 values not supported",
+      )
+    end
+
+    it "parses positive base-256 values with high values correctly" do
+      # Positive base-256: bit 7 set, bit 6 clear = 0x80
+      # This encodes the value 1000 (0x3E8) in base-256
+      positive_size = [0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x03, 0xE8].pack("C*")
+      header_data = create_header_with_base256_size(positive_size)
+      values = described_class.parse(header_data)
+
+      expect(values[:size]).to eq(1000)
     end
   end
 end

--- a/spec/header_parser_spec.rb
+++ b/spec/header_parser_spec.rb
@@ -33,8 +33,18 @@ RSpec.describe MiniTarball::HeaderParser do
       expect(described_class.parse(nil)).to be_nil
     end
 
-    it "returns nil for data shorter than block size" do
-      expect(described_class.parse("short")).to be_nil
+    it "raises InvalidHeaderError for truncated header" do
+      expect { described_class.parse("short") }.to raise_error(
+        MiniTarball::InvalidHeaderError,
+        "Truncated header",
+      )
+    end
+
+    it "raises InvalidHeaderError for header just under block size" do
+      expect { described_class.parse("x" * 511) }.to raise_error(
+        MiniTarball::InvalidHeaderError,
+        "Truncated header",
+      )
     end
 
     it "returns nil for end-of-archive marker" do

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -221,6 +221,78 @@ RSpec.describe MiniTarball::Reader do
         expect(contents["small.txt"]).to eq("small")
       end
     end
+
+    context "with max_file_size validation" do
+      def create_file_header(size:)
+        MiniTarball::Header.new(
+          name: "large.txt",
+          mode: 0644,
+          uid: 0,
+          gid: 0,
+          size:,
+          uname: "root",
+          gname: "root",
+        )
+      end
+
+      it "raises error for file exceeding max_file_size" do
+        # Create a header claiming 10GB size
+        header = create_file_header(size: 10_000_000_000)
+        tar_data = header.to_binary + ("\0" * 1024)
+
+        tar_io = StringIO.new(tar_data).binmode
+        expect do described_class.use(tar_io) { |reader| reader.each_entry {} } end.to raise_error(
+          MiniTarball::InvalidHeaderError,
+          /File size exceeds maximum/,
+        )
+      end
+
+      it "allows custom max_file_size" do
+        # Create a header claiming 1KB size
+        header = create_file_header(size: 1024)
+        content = "x" * 1024
+        padding = "\0" * (512 - (1024 % 512))
+        tar_data = header.to_binary + content + padding + ("\0" * 1024)
+
+        tar_io = StringIO.new(tar_data).binmode
+        # Set max to 500 bytes - should reject 1KB file
+        expect do
+          described_class.use(tar_io, max_file_size: 500) { |reader| reader.each_entry {} }
+        end.to raise_error(MiniTarball::InvalidHeaderError, /File size exceeds maximum/)
+      end
+
+      it "accepts file at exactly max_file_size" do
+        io = StringIO.new.binmode
+        content = "x" * 100
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: "exact.txt") { |s| s.write(content) }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        entries = []
+        described_class.use(tar_io, max_file_size: 100) do |reader|
+          reader.each_entry { |entry, _| entries << entry.name }
+        end
+
+        expect(entries).to eq(["exact.txt"])
+      end
+
+      it "uses default 8GB limit" do
+        io = StringIO.new.binmode
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: "normal.txt") { |s| s.write("content") }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        entries = []
+        # Default should allow normal files
+        described_class.use(tar_io) do |reader|
+          reader.each_entry { |entry, _| entries << entry.name }
+        end
+
+        expect(entries).to eq(["normal.txt"])
+      end
+    end
   end
 
   describe "#close" do

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -194,6 +194,33 @@ RSpec.describe MiniTarball::Reader do
         expect(entries).to eq([long_name])
       end
     end
+
+    context "with chunked skipping" do
+      it "correctly skips large unread content between entries" do
+        io = StringIO.new.binmode
+        # Create a file with content larger than skip chunk size (64KB)
+        large_content = "x" * 100_000
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: "large.txt") { |s| s.write(large_content) }
+          writer.add_file_from_stream(name: "small.txt") { |s| s.write("small") }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        entries = []
+        contents = {}
+
+        described_class.use(tar_io) do |reader|
+          reader.each_entry do |entry, stream|
+            entries << entry.name
+            # Only read the second file's content, skip the first
+            contents[entry.name] = stream.read if entry.name == "small.txt"
+          end
+        end
+
+        expect(entries).to eq(%w[large.txt small.txt])
+        expect(contents["small.txt"]).to eq("small")
+      end
+    end
   end
 
   describe "#close" do

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -271,6 +271,34 @@ RSpec.describe MiniTarball::Reader do
 
         expect(entries).to eq([long_name])
       end
+
+      it "raises TruncatedArchiveError for truncated long name content" do
+        # Create a long name header claiming 200 bytes but only provide 50
+        header = create_long_name_header(size: 200, typeflag: "L")
+        tar_data = header + ("x" * 50) # Truncated - only 50 bytes instead of 200
+
+        tar_io = StringIO.new(tar_data).binmode
+        expect do described_class.use(tar_io) { |reader| reader.each_entry {} } end.to raise_error(
+          MiniTarball::TruncatedArchiveError,
+          /Unexpected end of archive/,
+        )
+      end
+
+      it "raises TruncatedArchiveError when padding is missing" do
+        io = StringIO.new.binmode
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: "one.txt") { |s| s.write("a") }
+        end
+
+        # Truncate to header + 1 byte, omitting padding and end-of-archive
+        truncated = io.string[0, 513]
+        tar_io = StringIO.new(truncated).binmode
+
+        expect do described_class.use(tar_io) { |reader| reader.each_entry {} } end.to raise_error(
+          MiniTarball::TruncatedArchiveError,
+          /Unexpected end of archive/,
+        )
+      end
     end
 
     context "with chunked skipping" do
@@ -639,6 +667,26 @@ RSpec.describe MiniTarball::Reader do
         described_class.use(tar_io) { |reader| reader.extract_all(tmpdir) }
 
         expect(File.read(File.join(tmpdir, "a/b/c/d/deep.txt"))).to eq("deep")
+      end
+
+      it "rejects extraction when the target path is an existing symlink" do
+        outside_dir = Dir.mktmpdir
+        begin
+          symlink_path = File.join(tmpdir, "leaf")
+          File.symlink(outside_dir, symlink_path)
+
+          io = StringIO.new.binmode
+          MiniTarball::Writer.use(io) do |writer|
+            writer.add_file_from_stream(name: "leaf") { |s| s.write("pwned") }
+          end
+
+          tar_io = StringIO.new(io.string).binmode
+          expect do
+            described_class.use(tar_io) { |reader| reader.extract_all(tmpdir) }
+          end.to raise_error(MiniTarball::PathTraversalError, /Symlink at destination path/)
+        ensure
+          FileUtils.rm_rf(outside_dir)
+        end
       end
     end
 

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -357,6 +357,61 @@ RSpec.describe MiniTarball::Reader do
       end.to raise_error(MiniTarball::PathTraversalError)
     end
 
+    context "with symlink-in-path attacks" do
+      it "rejects extraction through pre-existing symlink pointing outside destination" do
+        # Create a symlink inside tmpdir pointing to /tmp (outside destination)
+        outside_dir = Dir.mktmpdir
+        begin
+          symlink_path = File.join(tmpdir, "escape_link")
+          File.symlink(outside_dir, symlink_path)
+
+          # Create a tar that writes through the symlink
+          io = StringIO.new.binmode
+          MiniTarball::Writer.use(io) do |writer|
+            writer.add_file_from_stream(name: "escape_link/pwned.txt") { |s| s.write("pwned") }
+          end
+
+          tar_io = StringIO.new(io.string).binmode
+          expect do
+            described_class.use(tar_io) { |reader| reader.extract_all(tmpdir) }
+          end.to raise_error(MiniTarball::PathTraversalError, /Symlink in path escapes destination/)
+        ensure
+          FileUtils.rm_rf(outside_dir)
+        end
+      end
+
+      it "allows extraction through symlink pointing within destination" do
+        # Create a subdirectory and symlink to it within tmpdir
+        real_dir = File.join(tmpdir, "real_subdir")
+        FileUtils.mkdir_p(real_dir)
+        symlink_path = File.join(tmpdir, "link_to_subdir")
+        File.symlink(real_dir, symlink_path)
+
+        io = StringIO.new.binmode
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: "link_to_subdir/file.txt") { |s| s.write("content") }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        described_class.use(tar_io) { |reader| reader.extract_all(tmpdir) }
+
+        expect(File.read(File.join(real_dir, "file.txt"))).to eq("content")
+      end
+
+      it "handles deeply nested paths correctly" do
+        io = StringIO.new.binmode
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_directory(name: "a/b/c/d")
+          writer.add_file_from_stream(name: "a/b/c/d/deep.txt") { |s| s.write("deep") }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        described_class.use(tar_io) { |reader| reader.extract_all(tmpdir) }
+
+        expect(File.read(File.join(tmpdir, "a/b/c/d/deep.txt"))).to eq("deep")
+      end
+    end
+
     it "returns self for chaining" do
       tar_io = create_tar
       reader = described_class.new(tar_io)

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -135,6 +135,65 @@ RSpec.describe MiniTarball::Reader do
 
       expect(result).to be(reader)
     end
+
+    context "with malicious long name/linkname entries" do
+      def create_long_name_header(size:, typeflag:)
+        # Create a valid GNU long name/linkname header
+        header =
+          MiniTarball::Header.new(
+            name: "././@LongLink",
+            mode: 0644,
+            uid: 0,
+            gid: 0,
+            size:,
+            typeflag:,
+            uname: "root",
+            gname: "root",
+          )
+        header.to_binary
+      end
+
+      it "raises error for oversized long name entry" do
+        # Create a tar with a long name entry claiming 100KB size
+        header = create_long_name_header(size: 100_000, typeflag: "L")
+        # Append minimal content and padding (doesn't matter, error raised before reading)
+        tar_data = header + ("x" * 512) + ("\0" * 1024)
+
+        tar_io = StringIO.new(tar_data).binmode
+        expect do described_class.use(tar_io) { |reader| reader.each_entry {} } end.to raise_error(
+          MiniTarball::InvalidHeaderError,
+          "Long name too large",
+        )
+      end
+
+      it "raises error for oversized long linkname entry" do
+        header = create_long_name_header(size: 100_000, typeflag: "K")
+        tar_data = header + ("x" * 512) + ("\0" * 1024)
+
+        tar_io = StringIO.new(tar_data).binmode
+        expect do described_class.use(tar_io) { |reader| reader.each_entry {} } end.to raise_error(
+          MiniTarball::InvalidHeaderError,
+          "Long linkname too large",
+        )
+      end
+
+      it "accepts long name entries within size limit" do
+        # 65535 bytes is at the limit
+        io = StringIO.new.binmode
+        long_name = "a" * 65_000 + ".txt"
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: long_name) { |s| s.write("content") }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        entries = []
+        described_class.use(tar_io) do |reader|
+          reader.each_entry { |entry, _| entries << entry.name }
+        end
+
+        expect(entries).to eq([long_name])
+      end
+    end
   end
 
   describe "#close" do

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -135,7 +135,85 @@ RSpec.describe MiniTarball::Reader do
 
       expect(result).to be(reader)
     end
+  end
 
+  describe "#each_file" do
+    it "iterates over file entries only" do
+      io = StringIO.new.binmode
+      MiniTarball::Writer.use(io) do |writer|
+        writer.add_directory(name: "subdir")
+        writer.add_file_from_stream(name: "file1.txt") { |s| s.write("content1") }
+        writer.add_symlink(name: "link.txt", target: "file1.txt")
+        writer.add_file_from_stream(name: "file2.txt") { |s| s.write("content2") }
+      end
+
+      tar_io = StringIO.new(io.string).binmode
+      files = []
+
+      described_class.use(tar_io) { |reader| reader.each_file { |entry, _| files << entry.name } }
+
+      expect(files).to eq(%w[file1.txt file2.txt])
+    end
+
+    it "provides working content streams" do
+      io = StringIO.new.binmode
+      MiniTarball::Writer.use(io) do |writer|
+        writer.add_directory(name: "dir")
+        writer.add_file_from_stream(name: "test.txt") { |s| s.write("hello") }
+      end
+
+      tar_io = StringIO.new(io.string).binmode
+      content = nil
+
+      described_class.use(tar_io) do |reader|
+        reader.each_file { |_, stream| content = stream.read }
+      end
+
+      expect(content).to eq("hello")
+    end
+
+    it "returns an enumerator without block" do
+      tar_io = create_tar
+      reader = described_class.new(tar_io)
+
+      enum = reader.each_file
+      expect(enum).to be_a(Enumerator)
+
+      entry, stream = enum.next
+      expect(entry.name).to eq("hello.txt")
+      expect(entry.file?).to be true
+    end
+
+    it "returns self for chaining" do
+      tar_io = create_tar
+      reader = described_class.new(tar_io)
+
+      result = reader.each_file {}
+
+      expect(result).to be(reader)
+    end
+
+    it "exposes stream size and position for upload SDKs" do
+      io = StringIO.new.binmode
+      MiniTarball::Writer.use(io) do |writer|
+        writer.add_file_from_stream(name: "test.txt") { |s| s.write("hello world") }
+      end
+
+      tar_io = StringIO.new(io.string).binmode
+      stream_info = nil
+
+      described_class.use(tar_io) do |reader|
+        reader.each_file do |_, stream|
+          stream.read(5)
+          stream_info = { size: stream.size, pos: stream.pos, remaining: stream.remaining }
+        end
+      end
+
+      expect(stream_info).to eq({ size: 11, pos: 5, remaining: 6 })
+    end
+  end
+
+  describe "#each_entry" do
     context "with malicious long name/linkname entries" do
       def create_long_name_header(size:, typeflag:)
         # Create a valid GNU long name/linkname header

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -293,6 +293,86 @@ RSpec.describe MiniTarball::Reader do
         expect(entries).to eq(["normal.txt"])
       end
     end
+
+    context "with max_total_size validation" do
+      it "raises error when total size exceeds limit" do
+        io = StringIO.new.binmode
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: "file1.txt") { |s| s.write("a" * 100) }
+          writer.add_file_from_stream(name: "file2.txt") { |s| s.write("b" * 100) }
+          writer.add_file_from_stream(name: "file3.txt") { |s| s.write("c" * 100) }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        # Total is 300 bytes, limit to 250
+        expect do
+          described_class.use(tar_io, max_total_size: 250) { |reader| reader.each_entry {} }
+        end.to raise_error(MiniTarball::ArchiveLimitError, /Total size exceeds maximum/)
+      end
+
+      it "allows archives within total size limit" do
+        io = StringIO.new.binmode
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: "file1.txt") { |s| s.write("a" * 100) }
+          writer.add_file_from_stream(name: "file2.txt") { |s| s.write("b" * 100) }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        entries = []
+        described_class.use(tar_io, max_total_size: 200) do |reader|
+          reader.each_entry { |entry, _| entries << entry.name }
+        end
+
+        expect(entries).to eq(%w[file1.txt file2.txt])
+      end
+    end
+
+    context "with max_entry_count validation" do
+      it "raises error when entry count exceeds limit" do
+        io = StringIO.new.binmode
+        MiniTarball::Writer.use(io) do |writer|
+          5.times { |i| writer.add_file_from_stream(name: "file#{i}.txt") { |s| s.write("x") } }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        expect do
+          described_class.use(tar_io, max_entry_count: 3) { |reader| reader.each_entry {} }
+        end.to raise_error(MiniTarball::ArchiveLimitError, /Entry count exceeds maximum/)
+      end
+
+      it "allows archives within entry count limit" do
+        io = StringIO.new.binmode
+        MiniTarball::Writer.use(io) do |writer|
+          3.times { |i| writer.add_file_from_stream(name: "file#{i}.txt") { |s| s.write("x") } }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        entries = []
+        described_class.use(tar_io, max_entry_count: 3) do |reader|
+          reader.each_entry { |entry, _| entries << entry.name }
+        end
+
+        expect(entries).to eq(%w[file0.txt file1.txt file2.txt])
+      end
+
+      it "does not count long name entries toward limit" do
+        io = StringIO.new.binmode
+        long_name = "a" * 150 + ".txt"
+        MiniTarball::Writer.use(io) do |writer|
+          writer.add_file_from_stream(name: long_name) { |s| s.write("content") }
+          writer.add_file_from_stream(name: "short.txt") { |s| s.write("content") }
+        end
+
+        tar_io = StringIO.new(io.string).binmode
+        entries = []
+        # Long name uses internal ././@LongLink entry, but should only count as 1 user entry
+        described_class.use(tar_io, max_entry_count: 2) do |reader|
+          reader.each_entry { |entry, _| entries << entry.name }
+        end
+
+        expect(entries).to eq([long_name, "short.txt"])
+      end
+    end
   end
 
   describe "#close" do

--- a/spec/streams/bounded_read_stream_spec.rb
+++ b/spec/streams/bounded_read_stream_spec.rb
@@ -61,4 +61,38 @@ RSpec.describe MiniTarball::BoundedReadStream do
       expect(stream.remaining).to eq(7)
     end
   end
+
+  describe "#size" do
+    it "returns the total size" do
+      stream = described_class.new(io, size: 10)
+      expect(stream.size).to eq(10)
+    end
+
+    it "remains constant after reads" do
+      stream = described_class.new(io, size: 10)
+      stream.read(5)
+      expect(stream.size).to eq(10)
+    end
+  end
+
+  describe "#pos" do
+    it "returns 0 before any reads" do
+      stream = described_class.new(io, size: 10)
+      expect(stream.pos).to eq(0)
+    end
+
+    it "returns bytes read so far" do
+      stream = described_class.new(io, size: 10)
+      stream.read(3)
+      expect(stream.pos).to eq(3)
+      stream.read(4)
+      expect(stream.pos).to eq(7)
+    end
+
+    it "is aliased as tell" do
+      stream = described_class.new(io, size: 10)
+      stream.read(5)
+      expect(stream.tell).to eq(5)
+    end
+  end
 end

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -320,6 +320,24 @@ RSpec.describe MiniTarball::Writer do
         }.not_to raise_error
       end
     end
+
+    it "rejects nil target" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect { writer.add_symlink(name: "link.txt", target: nil) }.to raise_error(
+          MiniTarball::UnsafeNameError,
+          /Empty target not allowed/,
+        )
+      end
+    end
+
+    it "rejects empty target" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect { writer.add_symlink(name: "link.txt", target: "") }.to raise_error(
+          MiniTarball::UnsafeNameError,
+          /Empty target not allowed/,
+        )
+      end
+    end
   end
 
   describe "#add_hardlink" do

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -121,6 +121,44 @@ RSpec.describe MiniTarball::Writer do
       end
     end
 
+    it "rejects bare .. as path traversal" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect { writer.add_file(name: "..", source_file_path: source_path) }.to raise_error(
+          MiniTarball::UnsafeNameError,
+          /Path traversal is not allowed/,
+        )
+      end
+    end
+
+    it "rejects Windows absolute paths" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect {
+          writer.add_file(name: "C:\\Windows\\System32\\file.txt", source_file_path: source_path)
+        }.to raise_error(MiniTarball::UnsafeNameError, /Absolute paths are not allowed/)
+
+        expect {
+          writer.add_file(name: "\\\\server\\share\\file.txt", source_file_path: source_path)
+        }.to raise_error(MiniTarball::UnsafeNameError, /Absolute paths are not allowed/)
+      end
+    end
+
+    it "rejects path traversal with backslashes" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect {
+          writer.add_file(name: "foo\\..\\..\\etc\\passwd", source_file_path: source_path)
+        }.to raise_error(MiniTarball::UnsafeNameError, /Path traversal is not allowed/)
+      end
+    end
+
+    it "rejects empty name" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect { writer.add_file(name: "", source_file_path: source_path) }.to raise_error(
+          MiniTarball::UnsafeNameError,
+          /Empty name not allowed/,
+        )
+      end
+    end
+
     it "allows relative paths without traversal" do
       MiniTarball::Writer.use(io) do |writer|
         expect {
@@ -256,6 +294,32 @@ RSpec.describe MiniTarball::Writer do
         expect { writer.add_symlink(name: "link.txt", target: "a" * 100) }.not_to raise_error
       end
     end
+
+    it "rejects absolute target paths" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect { writer.add_symlink(name: "link.txt", target: "/etc/passwd") }.to raise_error(
+          MiniTarball::UnsafeNameError,
+          /Absolute target paths are not allowed/,
+        )
+      end
+    end
+
+    it "rejects Windows absolute target paths" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect {
+          writer.add_symlink(name: "link.txt", target: "C:\\Windows\\System32")
+        }.to raise_error(MiniTarball::UnsafeNameError, /Absolute target paths are not allowed/)
+      end
+    end
+
+    it "allows relative targets with .." do
+      MiniTarball::Writer.use(io) do |writer|
+        # Relative targets with .. are valid (pointing to sibling directories)
+        expect {
+          writer.add_symlink(name: "subdir/link.txt", target: "../sibling/file.txt")
+        }.not_to raise_error
+      end
+    end
   end
 
   describe "#add_hardlink" do
@@ -302,6 +366,23 @@ RSpec.describe MiniTarball::Writer do
         system("tar", "-xf", tar_path, "-C", temp_dir)
         expect(File.exist?(File.join(temp_dir, "link.txt"))).to be true
         expect(File.read(File.join(temp_dir, "link.txt"))).to eq("content")
+      end
+    end
+
+    it "rejects absolute target paths" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect { writer.add_hardlink(name: "link.txt", target: "/etc/passwd") }.to raise_error(
+          MiniTarball::UnsafeNameError,
+          /Absolute target paths are not allowed/,
+        )
+      end
+    end
+
+    it "rejects Windows absolute target paths" do
+      MiniTarball::Writer.use(io) do |writer|
+        expect {
+          writer.add_hardlink(name: "link.txt", target: "C:\\important\\file")
+        }.to raise_error(MiniTarball::UnsafeNameError, /Absolute target paths are not allowed/)
       end
     end
   end


### PR DESCRIPTION
## Summary

Comprehensive security hardening for the Reader class:

- Reject truncated tar headers instead of silent EOF
- Reject negative base-256 and octal values in header parser
- Add size limits for GNU long name/linkname entries (64KB max)
- Use chunked reads in skip_remaining to prevent DoS
- Validate path components against symlink-in-path attacks
- Complete path traversal validation in Writer (Windows paths, backslashes)
- Add maximum file size validation (default 8GB)
- Add `max_total_size` (default 50GB) and `max_entry_count` (default 100K) limits for zip-bomb protection
- Add `each_file` method for streaming file uploads
- Handle truncated content and padding issues

## Test plan

- [x] All existing tests pass
- [x] Malicious headers are rejected (oversized, negative, truncated)
- [x] Path traversal attempts are blocked
- [x] Symlink-in-path attacks are detected
- [x] Archive limits are enforced